### PR TITLE
Add route names extender configuration option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/
 ide.json
 
 composer.lock
+/.build/

--- a/composer.json
+++ b/composer.json
@@ -69,5 +69,9 @@
                 "DragonCode\\LaravelRouteNames\\ServiceProvider"
             ]
         }
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit --coverage-text",
+        "test-coverage": "@test --coverage-html=.build/phpunit/"
     }
 }

--- a/config/route.php
+++ b/config/route.php
@@ -32,5 +32,16 @@ return [
             'sanctum*',
             'telescope*',
         ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Extender
+        |--------------------------------------------------------------------------
+        |
+        | This option specifies the callback that will be used to extend route names.
+        |
+        */
+
+        'extender' => null,
     ],
 ];

--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -14,7 +14,10 @@ class Route extends BaseRoute
     {
         return $this->isProtectedRouteName()
             ? $this->getProtectedRouteName()
-            : Name::get($this->methods(), $this->uri());
+            : app()->call($this->getRouteNamesExtender(), [
+                'name'  => Name::get($this->methods(), $this->uri()),
+                'route' => $this,
+            ]);
     }
 
     protected function isProtectedRouteName(): bool
@@ -34,5 +37,13 @@ class Route extends BaseRoute
     protected function getProtectedRouteNames(): array
     {
         return config('route.names.exclude');
+    }
+
+    /**
+     * @return (callable(string, self): string)|string
+     */
+    protected function getRouteNamesExtender()
+    {
+        return config('route.names.extender') ?: static fn (string $name): string => $name;
     }
 }

--- a/tests/Concerns/Routes.php
+++ b/tests/Concerns/Routes.php
@@ -118,4 +118,14 @@ trait Routes
         $router->get('telescope/{view?}', [Controller::class, 'telescopeShow'])->name('telescope');
         $router->get('telescope/telescope-api/views/{telescopeEntryId}', [Controller::class, 'telescopeViewsShow']);
     }
+
+    protected function extendedRoutes(Router $router): void
+    {
+        $router->get('api/v1/extended/', [Controller::class, 'extendedFoo']);
+        $router->post('api/v1/extended/', [Controller::class, 'extendedBar']);
+        $router->put('api/v1/extended/', [Controller::class, 'extendedBaz']);
+        $router->delete('api/v1/extended/', [Controller::class, 'extendedBaq']);
+        $router->patch('api/v1/extended/', [Controller::class, 'extendedBaw']);
+        $router->options('api/v1/extended/', [Controller::class, 'extendedBae']);
+    }
 }

--- a/tests/Extenders/RouteNameExtender.php
+++ b/tests/Extenders/RouteNameExtender.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Extenders;
+
+use DragonCode\LaravelRouteNames\Routing\Route;
+use Illuminate\Support\Str;
+
+final class RouteNameExtender
+{
+    public function __invoke(string $name, Route $route): string
+    {
+        return Str::of($route->uri())->startsWith('api/v1')
+            ? Str::replaceFirst('api.v1', 'api.v2', $name)
+            : $name;
+    }
+}

--- a/tests/Routes/ExtendedRoutesTest.php
+++ b/tests/Routes/ExtendedRoutesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Routes;
+
+use DragonCode\LaravelRouteNames\Routing\Route;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
+use Tests\Extenders\RouteNameExtender;
+use Tests\TestCase;
+
+final class ExtendedRoutesTest extends TestCase
+{
+    public function testWebDefault(): void
+    {
+        $this->assertSame('api.v1.extended.index', $this->getRouteName('extendedFoo'));
+        $this->assertSame('api.v1.extended.store', $this->getRouteName('extendedBar'));
+        $this->assertSame('api.v1.extended.update', $this->getRouteName('extendedBaz'));
+        $this->assertSame('api.v1.extended.destroy', $this->getRouteName('extendedBaq'));
+        $this->assertSame('api.v1.extended.patch', $this->getRouteName('extendedBaw'));
+        $this->assertSame('api.v1.extended.options', $this->getRouteName('extendedBae'));
+    }
+
+    public function testWebCallback(): void
+    {
+        Config::set(
+            'route.names.extender',
+            static function (string $name, Route $route): string {
+                return Str::of($route->uri())->startsWith('api/v1')
+                    ? Str::replaceFirst('api.v1', 'api', $name)
+                    : $name;
+            }
+        );
+
+        $this->assertSame('api.extended.index', $this->getRouteName('extendedFoo'));
+        $this->assertSame('api.extended.store', $this->getRouteName('extendedBar'));
+        $this->assertSame('api.extended.update', $this->getRouteName('extendedBaz'));
+        $this->assertSame('api.extended.destroy', $this->getRouteName('extendedBaq'));
+        $this->assertSame('api.extended.patch', $this->getRouteName('extendedBaw'));
+        $this->assertSame('api.extended.options', $this->getRouteName('extendedBae'));
+    }
+
+    public function testWebSpecialCallback(): void
+    {
+        Config::set('route.names.extender', RouteNameExtender::class);
+
+        $this->assertSame('api.v2.extended.index', $this->getRouteName('extendedFoo'));
+        $this->assertSame('api.v2.extended.store', $this->getRouteName('extendedBar'));
+        $this->assertSame('api.v2.extended.update', $this->getRouteName('extendedBaz'));
+        $this->assertSame('api.v2.extended.destroy', $this->getRouteName('extendedBaq'));
+        $this->assertSame('api.v2.extended.patch', $this->getRouteName('extendedBaw'));
+        $this->assertSame('api.v2.extended.options', $this->getRouteName('extendedBae'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,6 +56,7 @@ abstract class TestCase extends BaseTestCase
         $this->collisionRoutes($router);
         $this->mixedCases($router);
         $this->protectedRoutes($router);
+        $this->extendedRoutes($router);
         $this->routesWithMultiParameters($router);
         $this->routesWithParameters($router);
     }


### PR DESCRIPTION
Currently, this project does not support customizing or extending route names. Therefore, it is not possible to personalize some route names in bulk. This `PR` has already solved this problem.